### PR TITLE
Adding CI folder for dp-reporter-client to test new Library pipeline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD=build
 BUILD_ARCH=$(BUILD)/$(GOOS)-$(GOARCH)
 BIN_DIR?=.
 
-PHONY: all
+.PHONY: all
 all: audit test build
 
 PHONY: audit

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+MAIN=dp-reporter-client
+
+BUILD=build
+BUILD_ARCH=$(BUILD)/$(GOOS)-$(GOARCH)
+BIN_DIR?=.
+
+PHONY: all
+all: audit test build
+
+PHONY: audit
+audit:
+	go list -m all | nancy sleuth
+
+PHONY: build
+build:
+	@mkdir -p $(BUILD_ARCH)/$(BIN_DIR)
+	go build $(LDFLAGS) -o $(BUILD_ARCH)/$(BIN_DIR)/$(MAIN)
+
+PHONY: test
 test:
 	go test -race -cover ./...
-.PHONY: test
+
+
+.PHONY: build debug test

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,14 @@
-MAIN=dp-reporter-client
-
-BUILD=build
-BUILD_ARCH=$(BUILD)/$(GOOS)-$(GOARCH)
-BIN_DIR?=.
-
 .PHONY: all
 all: audit test build
 
-PHONY: audit
+.PHONY: audit
 audit:
 	go list -m all | nancy sleuth
 
-PHONY: build
+.PHONY: build
 build:
-	@mkdir -p $(BUILD_ARCH)/$(BIN_DIR)
-	go build $(LDFLAGS) -o $(BUILD_ARCH)/$(BIN_DIR)/$(MAIN)
+	go build ./...
 
-PHONY: test
+.PHONY: test
 test:
 	go test -race -cover ./...
-
-
-.PHONY: build debug test

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: onsdigital/dp-concourse-tools-nancy
+    tag: latest
+
+inputs:
+  - name: dp-reporter-client
+    path: dp-reporter-client
+
+run:
+  path: reporter-client/ci/scripts/audit.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,19 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.13.8
+
+inputs:
+  - name: dp-reporter-client
+    path: dp-reporter-client
+
+# outputs:
+#   - name: build
+
+run:
+  path: dp-reporter-client/ci/scripts/build.sh

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,14 +6,11 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.8
+    tag: 1.15
 
 inputs:
   - name: dp-reporter-client
     path: dp-reporter-client
-
-# outputs:
-#   - name: build
 
 run:
   path: dp-reporter-client/ci/scripts/build.sh

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -3,5 +3,5 @@
 cwd=$(pwd)
 
 pushd $cwd/dp-reporter-client
-  nancy build && mv build/dp-reporter-client $cwd/build
+  make audit
 popd

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-reporter-client
+  nancy build && mv build/dp-reporter-client $cwd/build
+popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+
+# cwd=$(pwd)
+
+# pushd $cwd/dp-dimension-search-api
+make build ##&& mv build/$(go env GOOS)-$(go env GOARCH)/* $cwd/build
+  # cp Dockerfile.concourse $cwd/build
+# popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,1 +1,8 @@
-make build
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-reporter-client
+  make build && mv build/dp-reporter-client $cwd/build
+  cp Dockerfile.concourse $cwd/build
+popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -3,6 +3,5 @@
 cwd=$(pwd)
 
 pushd $cwd/dp-reporter-client
-  make build && mv build/dp-reporter-client $cwd/build
-  cp Dockerfile.concourse $cwd/build
+  make build
 popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,8 +1,1 @@
-#!/bin/bash -eux
-
-# cwd=$(pwd)
-
-# pushd $cwd/dp-dimension-search-api
-make build ##&& mv build/$(go env GOOS)-$(go env GOARCH)/* $cwd/build
-  # cp Dockerfile.concourse $cwd/build
-# popd
+make build

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -1,7 +1,1 @@
-#!/bin/bash -eux
-
-#cwd=$(pwd)
-
-#pushd $cwd/dp-dimension-search-api
 make test
-#popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+#cwd=$(pwd)
+
+#pushd $cwd/dp-dimension-search-api
+make test
+#popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -1,1 +1,7 @@
-make test
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-search-builder
+  make test
+popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -1,0 +1,16 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.13.8
+
+inputs:
+  - name: dp-reporter-client
+    path: dp-reporter-client
+
+run:
+  path: dp-reporter-client/ci/scripts/unit.sh

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.8
+    tag: 1.15
 
 inputs:
   - name: dp-reporter-client


### PR DESCRIPTION
### What
Part of a series of PR's to create a new pipeline process to test Libraries:
feature/concourse-template-libraries-test1-ci (https://github.com/ONSdigital/dp-ci/pull/821)
feature/concourse-template-libraries-test1-configs

This PR is first of a few iterations to build up the functionality of the new Concourse pipeline process.  Library to test with new the Concourse Library template.

NOTE: This pipeline will be deleted from Concourse in due course as this is only a test.

ci/scripts/build.sh
  Typical build sh minus some functionality, which is commented out.  
ci/scripts/unit.sh
  Typical uni sh minus some functionality, which is commented out.
ci/unit.yml
ci/build.yml
  Typical build yml minus some functionality, which is commented out.

### How to review
Manually review scripts/config files.  Very similar to a new app.

### Who can review
Anyone really.  This is only a test.  The pipeline will be removed after testing.
